### PR TITLE
Do not include unnecessary packages in Dockerfile

### DIFF
--- a/wildfly-bootable-jaxrs-archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/wildfly-bootable-jaxrs-archetype/src/main/resources/archetype-resources/Dockerfile
@@ -1,8 +1,5 @@
 FROM azul/zulu-openjdk-alpine:8
 
-RUN apk add bash curl nss tree \
-        && rm -rf /var/cache/apk/*
-
 ARG APP_NAME
 
 ENV APP_NAME ${APP_NAME}


### PR DESCRIPTION
Since people generally tend to prefer Alpine Linux for its small footprint, I would suggest that any non-essential packages are not included in the Docker image by default.